### PR TITLE
use otp style relative path instead of absolute path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "data"]
-	path = data
+[submodule "priv/data"]
+	path = priv/data
 	url = https://github.com/cn/GB2260.git

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
-%{"benchfella": {:hex, :benchfella, "0.3.2"},
-  "earmark": {:hex, :earmark, "0.1.19"},
-  "ex_doc": {:hex, :ex_doc, "0.10.0"},
-  "poison": {:hex, :poison, "2.0.1"}}
+%{"benchfella": {:hex, :benchfella, "0.3.2", "b9648e77fa8d8b8b9fe8f54293bee63f7de03909b3af6ab22a0e546716a396fb", [:mix], []},
+  "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.12.0", "b774aabfede4af31c0301aece12371cbd25995a21bb3d71d66f5c2fe074c603f", [:mix], [{:earmark, "~> 0.2", [hex: :earmark, optional: false]}]},
+  "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []}}


### PR DESCRIPTION
`@data_path Path.join(__DIR__, "../../data")`

module 变量的值会在编译的时候确定，这样会把绝对路径编译进去，编译的代码失去可移植性
使用 func 生成的路径是相对路径
